### PR TITLE
C: fix memory leak when adding ref to writer

### DIFF
--- a/c/writer.c
+++ b/c/writer.c
@@ -266,6 +266,7 @@ int reftable_writer_add_ref(struct reftable_writer *w,
 		struct strbuf h = STRBUF_INIT;
 		strbuf_add(&h, ref->target_value, hash_size(w->opts.hash_id));
 		writer_index_hash(w, &h);
+		strbuf_release(&h);
 	}
 	return 0;
 }


### PR DESCRIPTION
Fix memory-leak when adding a ref record with non-NULL target vaule to a
reftable writer.