### PR TITLE
README: fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ bazel test c/...
 ```
 
 API is documented in side the [reftable.h
-header](https://github.com/google/reftable/blob/master/c/reftable.h).
+header](https://github.com/google/reftable/blob/master/c/include/reftable.h).
 
 It includes a fragment of the zlib library to provide uncompress2(), which is a
 recent addition to the API. zlib is licensed as follows:


### PR DESCRIPTION
The link to reftable.h added in 0819c74 ("Update README with a link to
Git code", 2020-01-09) was broken since 7cddcd0 ("C: move public
header to separate directory.", 2020-03-25) when the reftable.h file
was moved to the c/include/ directory.